### PR TITLE
Improve notebook animation for Colab

### DIFF
--- a/IIoT_simulation.ipynb
+++ b/IIoT_simulation.ipynb
@@ -155,15 +155,26 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "97b2f84e",
+  "cell_type": "markdown",
+  "id": "97b2f84e",
+  "metadata": {},
+  "source": [
+   "Execute `main()` below to launch the real-time visualization."
+  ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run_main",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "Execute `main()` below to launch the real-time visualization."
+    "from src.visualization import main\n",
+    "main(inline=True)"
    ]
   }
- ],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
+],
+"metadata": {},
+"nbformat": 4,
+"nbformat_minor": 5
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ python -m src.visualization
 
 A window will open showing a live graph of each sensor's output.
 
+When running in a Jupyter environment such as Google Colab, use:
+
+```python
+from src.visualization import main
+main(inline=True)
+```
+
+This returns an HTML animation that displays directly in the notebook.
+
 ## Directory Structure
 
 - `src/sensor.py` – definition of a simple sensor model

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -1,11 +1,17 @@
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
+try:
+    # Only available in notebook environments
+    from IPython.display import HTML
+except ImportError:  # pragma: no cover - IPython not installed
+    HTML = None
+
 from .sensor import Sensor
 from .monitor import Monitor
 
 
-def main():
+def main(inline: bool = False):
     sensors = [
         Sensor("Water Level", "m", 0.0, 10.0),
         Sensor("Flow Rate", "m3/s", 0.0, 5.0),
@@ -38,6 +44,9 @@ def main():
         return list(lines.values())
 
     ani = FuncAnimation(fig, update, interval=1000)
+    if inline and HTML is not None:
+        plt.close(fig)
+        return HTML(ani.to_jshtml())
     plt.show()
 
 


### PR DESCRIPTION
## Summary
- allow `main()` to output HTML animation for notebooks
- demonstrate inline usage in README
- add a notebook cell that runs the animation inline

## Testing
- `pip install matplotlib`
- `python -m src.visualization` (fails to render headless but runs)

------
https://chatgpt.com/codex/tasks/task_e_6876338dac18832a9e4c20921891d102